### PR TITLE
[ci skip] Add a comma in the Exceptions section of Active Support Instrumentation guide

### DIFF
--- a/guides/source/active_support_instrumentation.md
+++ b/guides/source/active_support_instrumentation.md
@@ -916,7 +916,7 @@ This event is only emitted when using the Google Cloud Storage service.
 Exceptions
 ----------
 
-If an exception happens during any instrumentation the payload will include
+If an exception happens during any instrumentation, the payload will include
 information about it.
 
 | Key                 | Value                                                          |


### PR DESCRIPTION
### Detail

Minor: added a missed comma in the Exceptions section.